### PR TITLE
Add AnnotationAssertions

### DIFF
--- a/src/main/java/io/blt/test/assertj/AnnotationAssertions.java
+++ b/src/main/java/io/blt/test/assertj/AnnotationAssertions.java
@@ -32,7 +32,11 @@ import org.assertj.core.internal.Failures;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class AnnotationAssertions {
+public final class AnnotationAssertions {
+
+    private AnnotationAssertions() {
+        throw new IllegalAccessError("Utility class should be accessed statically and never constructed");
+    }
 
     public static <T extends Annotation> ObjectAssert<T> assertHasAnnotation(Method method, Class<T> annotation) {
         return assertThat(findAnnotationOfTypeOrFail(method.getAnnotations(), annotation));

--- a/src/main/java/io/blt/test/assertj/AnnotationAssertions.java
+++ b/src/main/java/io/blt/test/assertj/AnnotationAssertions.java
@@ -1,0 +1,55 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Michael Cowan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.blt.test.assertj;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import org.assertj.core.api.ObjectAssert;
+import org.assertj.core.internal.Failures;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AnnotationAssertions {
+
+    public static <T extends Annotation> ObjectAssert<T> assertHasAnnotation(Method method, Class<T> annotation) {
+        return assertThat(findAnnotationOfTypeOrFail(method.getAnnotations(), annotation));
+    }
+
+    public static <T extends Annotation> ObjectAssert<T> assertHasAnnotation(Class<?> clazz, Class<T> annotation) {
+        return assertThat(findAnnotationOfTypeOrFail(clazz.getAnnotations(), annotation));
+    }
+
+    private static <T extends Annotation> T findAnnotationOfTypeOrFail(Annotation[] annotations, Class<T> type) {
+        var instance = Arrays.stream(annotations)
+                             .filter(a -> a.annotationType().equals(type))
+                             .findFirst()
+                             .orElseThrow(() -> Failures.instance().failure(
+                                     "Cannot find annotation of type " + type.getSimpleName()));
+
+        return type.cast(instance);
+    }
+
+}

--- a/src/main/java/io/blt/test/assertj/AnnotationAssertions.java
+++ b/src/main/java/io/blt/test/assertj/AnnotationAssertions.java
@@ -32,16 +32,76 @@ import org.assertj.core.internal.Failures;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Assertion factory methods that allow testing the annotations of various types.
+ * <p>
+ * Each method is a static factory for an annotation specific assertion object
+ * i.e. each method returns {@code ObjectAssert<T extends Annotation>}.
+ * </p>
+ * <p>
+ * e.g.
+ * <pre>{@code
+ * @Test
+ * void isAnnotatedAsTransactionalWithNoRollbackForException() {
+ *     assertHasAnnotation(NotificationPublisher.class, Transactional.class)
+ *             .extracting(Transactional::noRollbackFor)
+ *             .isEqualTo(Exception.class);
+ * }
+ * }</pre>
+ * </p>
+ */
 public final class AnnotationAssertions {
 
     private AnnotationAssertions() {
         throw new IllegalAccessError("Utility class should be accessed statically and never constructed");
     }
 
+    /**
+     * Asserts that a {@code Method} is annotated with a given annotation.
+     * <p>
+     * If present, an assertion object is returned for the found annotation instance, else the test fails.
+     * </p>
+     * e.g.
+     * <pre>{@code
+     * @Test
+     * void isAnnotatedAsTransactionalWithNoRollbackForException() throws Exception {
+     *     var method = NotificationPublisher.class.getMethod("sendNotification");
+     *
+     *     assertHasAnnotation(method, Transactional.class)
+     *             .extracting(Transactional::noRollbackFor)
+     *             .isEqualTo(Exception.class);
+     * }
+     * }</pre>
+     *
+     * @param method     a {@code Method} to test for the presence of {@code annotation}
+     * @param annotation the expected {@code Annotation} type
+     * @param <T>        type of {@code Annotation}
+     * @return an assertion object for the found annotation i.e. {@code ObjectAssert<T extends Annotation>}
+     */
     public static <T extends Annotation> ObjectAssert<T> assertHasAnnotation(Method method, Class<T> annotation) {
         return assertThat(findAnnotationOfTypeOrFail(method.getAnnotations(), annotation));
     }
 
+    /**
+     * Asserts that a {@code Class} is annotated with a given annotation.
+     * <p>
+     * If present, an assertion object is returned for the found annotation instance, else the test fails.
+     * </p>
+     * e.g.
+     * <pre>{@code
+     * @Test
+     * void isAnnotatedAsTransactionalWithNoRollbackForException() {
+     *     assertHasAnnotation(NotificationPublisher.class, Transactional.class)
+     *             .extracting(Transactional::noRollbackFor)
+     *             .isEqualTo(Exception.class);
+     * }
+     * }</pre>
+     *
+     * @param clazz      a {@code Class} to test for the presence of {@code annotation}
+     * @param annotation the expected {@code Annotation} type
+     * @param <T>        type of {@code Annotation}
+     * @return an assertion object for the found annotation i.e. {@code ObjectAssert<T extends Annotation>}
+     */
     public static <T extends Annotation> ObjectAssert<T> assertHasAnnotation(Class<?> clazz, Class<T> annotation) {
         return assertThat(findAnnotationOfTypeOrFail(clazz.getAnnotations(), annotation));
     }

--- a/src/test/java/io/blt/test/AssertUtils.java
+++ b/src/test/java/io/blt/test/AssertUtils.java
@@ -1,0 +1,65 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Michael Cowan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.blt.test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+public final class AssertUtils {
+
+    private AssertUtils() {}
+
+    public static void assertValidUtilityClass(Class<?> clazz) throws NoSuchMethodException {
+        assertThat(clazz)
+                .withFailMessage("Utility class must be final")
+                .isFinal();
+
+        assertThat(clazz.getDeclaredConstructors())
+                .withFailMessage("Utility class must only have a zero argument constructor")
+                .hasSize(1)
+                .extracting(Constructor::getParameterCount)
+                .hasSize(1);
+
+        var constructor = clazz.getDeclaredConstructor();
+
+        assertThat(constructor.getModifiers())
+                .withFailMessage("Constructor must be private")
+                .matches(Modifier::isPrivate);
+
+        constructor.setAccessible(true);
+
+        assertThatExceptionOfType(InvocationTargetException.class)
+                .describedAs("Utility class should throw if constructed")
+                .isThrownBy(constructor::newInstance)
+                .havingCause()
+                .isInstanceOf(IllegalAccessError.class)
+                .withMessage("Utility class should be accessed statically and never constructed");
+    }
+
+}

--- a/src/test/java/io/blt/test/assertj/AnnotationAssertionsTest.java
+++ b/src/test/java/io/blt/test/assertj/AnnotationAssertionsTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.opentest4j.AssertionFailedError;
 
+import static io.blt.test.AssertUtils.assertValidUtilityClass;
 import static io.blt.test.assertj.AnnotationAssertions.assertHasAnnotation;
 import static io.blt.test.assertj.testable.AnnotatedElements.TargetMethodAnnotation;
 import static io.blt.test.assertj.testable.AnnotatedElements.TargetTypeAnnotation;
@@ -47,6 +48,11 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 class AnnotationAssertionsTest {
+
+    @Test
+    void shouldBeValidUtilityClass() throws NoSuchMethodException {
+        assertValidUtilityClass(AnnotationAssertions.class);
+    }
 
     static Stream<Class<?>> assertHasAnnotationShouldThrowWhenTypeDoesntHaveAnnotation() {
         return Stream.of(TypeWithDifferentAnnotation.class, TypeWithNoAnnotation.class);

--- a/src/test/java/io/blt/test/assertj/AnnotationAssertionsTest.java
+++ b/src/test/java/io/blt/test/assertj/AnnotationAssertionsTest.java
@@ -1,0 +1,135 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Michael Cowan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.blt.test.assertj;
+
+import java.lang.reflect.Method;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opentest4j.AssertionFailedError;
+
+import static io.blt.test.assertj.AnnotationAssertions.assertHasAnnotation;
+import static io.blt.test.assertj.testable.AnnotatedElements.TargetMethodAnnotation;
+import static io.blt.test.assertj.testable.AnnotatedElements.TargetTypeAnnotation;
+import static io.blt.test.assertj.testable.AnnotatedElements.TypeWithDefaultTargetAnnotation;
+import static io.blt.test.assertj.testable.AnnotatedElements.TypeWithDifferentAnnotation;
+import static io.blt.test.assertj.testable.AnnotatedElements.TypeWithNoAnnotation;
+import static io.blt.test.assertj.testable.AnnotatedElements.TypeWithValueTargetAnnotation;
+import static io.blt.test.assertj.testable.AnnotatedElements.methodWithDefaultTargetAnnotation;
+import static io.blt.test.assertj.testable.AnnotatedElements.methodWithDifferentAnnotation;
+import static io.blt.test.assertj.testable.AnnotatedElements.methodWithNoAnnotations;
+import static io.blt.test.assertj.testable.AnnotatedElements.methodWithValueTargetAnnotation;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+class AnnotationAssertionsTest {
+
+    static Stream<Class<?>> assertHasAnnotationShouldThrowWhenTypeDoesntHaveAnnotation() {
+        return Stream.of(TypeWithDifferentAnnotation.class, TypeWithNoAnnotation.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void assertHasAnnotationShouldThrowWhenTypeDoesntHaveAnnotation(Class<?> type) {
+        assertThatExceptionOfType(AssertionError.class)
+                .isThrownBy(() -> assertHasAnnotation(type, TargetTypeAnnotation.class))
+                .withMessage("Cannot find annotation of type TargetTypeAnnotation");
+    }
+
+    @Test
+    void assertHasAnnotationShouldReturnObjectAssertForTypeWithFailCase() {
+        var objectAssert = assertHasAnnotation(TypeWithDefaultTargetAnnotation.class, TargetTypeAnnotation.class);
+
+        assertThatExceptionOfType(AssertionFailedError.class)
+                .isThrownBy(() -> objectAssert
+                        .extracting(TargetTypeAnnotation::name)
+                        .isEqualTo("wrong name"))
+                .withMessage(
+                        System.lineSeparator() + "expected: \"wrong name\"" +
+                        System.lineSeparator() + " but was: \"type annotation default name\"");
+    }
+
+    static Stream<Arguments> assertHasAnnotationShouldReturnObjectAssertForTypeWithSuccessCase() {
+        return Stream.of(
+                Arguments.arguments(TypeWithDefaultTargetAnnotation.class, "type annotation default name"),
+                Arguments.arguments(TypeWithValueTargetAnnotation.class, "type annotation value name"));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void assertHasAnnotationShouldReturnObjectAssertForTypeWithSuccessCase(Class<?> type, String expected) {
+        var objectAssert = assertHasAnnotation(type, TargetTypeAnnotation.class);
+
+        assertThatNoException()
+                .isThrownBy(() -> objectAssert
+                        .extracting(TargetTypeAnnotation::name)
+                        .isEqualTo(expected));
+    }
+
+    public static Stream<Method> assertHasAnnotationShouldThrowWhenMethodDoesntHaveAnnotation() {
+        return Stream.of(methodWithNoAnnotations, methodWithDifferentAnnotation);
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void assertHasAnnotationShouldThrowWhenMethodDoesntHaveAnnotation(Method method) {
+        assertThatExceptionOfType(AssertionError.class)
+                .isThrownBy(() -> assertHasAnnotation(method, TargetMethodAnnotation.class))
+                .withMessage("Cannot find annotation of type TargetMethodAnnotation");
+    }
+
+    @Test
+    void assertHasAnnotationShouldReturnObjectAssertForMethodWithFailCase() {
+        var objectAssert = assertHasAnnotation(methodWithDefaultTargetAnnotation, TargetMethodAnnotation.class);
+
+        assertThatExceptionOfType(AssertionFailedError.class)
+                .isThrownBy(() -> objectAssert
+                        .extracting(TargetMethodAnnotation::name)
+                        .isEqualTo("wrong name"))
+                .withMessage(
+                        System.lineSeparator() + "expected: \"wrong name\"" +
+                        System.lineSeparator() + " but was: \"method annotation default name\"");
+    }
+
+    static Stream<Arguments> assertHasAnnotationShouldReturnObjectAssertForMethodWithSuccessCase() {
+        return Stream.of(
+                Arguments.arguments(methodWithDefaultTargetAnnotation, "method annotation default name"),
+                Arguments.arguments(methodWithValueTargetAnnotation, "method annotation value name"));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void assertHasAnnotationShouldReturnObjectAssertForMethodWithSuccessCase(Method method, String expected) {
+        var objectAssert = assertHasAnnotation(method, TargetMethodAnnotation.class);
+
+        assertThatNoException()
+                .isThrownBy(() -> objectAssert
+                        .extracting(TargetMethodAnnotation::name)
+                        .isEqualTo(expected));
+    }
+
+}

--- a/src/test/java/io/blt/test/assertj/testable/AnnotatedElements.java
+++ b/src/test/java/io/blt/test/assertj/testable/AnnotatedElements.java
@@ -1,0 +1,95 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Michael Cowan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.blt.test.assertj.testable;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Method;
+
+/**
+ * Holds testable elements for annotation testing
+ */
+public final class AnnotatedElements {
+
+    @Target(ElementType.TYPE)
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface TargetTypeAnnotation {
+        String name() default "type annotation default name";
+    }
+
+    @Target(ElementType.TYPE)
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface DifferentTypeAnnotation {}
+
+    @TargetTypeAnnotation
+    public static class TypeWithDefaultTargetAnnotation {}
+
+    @TargetTypeAnnotation(name = "type annotation value name")
+    public static class TypeWithValueTargetAnnotation {}
+
+    @DifferentTypeAnnotation
+    public static class TypeWithDifferentAnnotation {}
+
+    public static class TypeWithNoAnnotation {}
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface TargetMethodAnnotation {
+        String name() default "method annotation default name";
+    }
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface DifferentMethodAnnotation {}
+
+    public static class MethodTests {
+        @TargetMethodAnnotation
+        public void methodWithDefaultTargetAnnotation() {}
+
+        @TargetMethodAnnotation(name = "method annotation value name")
+        public void methodWithValueTargetAnnotation() {}
+
+        @DifferentMethodAnnotation
+        public void methodWithDifferentAnnotation() {}
+
+        public void methodWithNoAnnotations() {}
+
+        private static Method method(String name) {
+            try {
+                return MethodTests.class.getMethod(name);
+            } catch (NoSuchMethodException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    public static Method methodWithDefaultTargetAnnotation = MethodTests.method("methodWithDefaultTargetAnnotation");
+    public static Method methodWithValueTargetAnnotation = MethodTests.method("methodWithValueTargetAnnotation");
+    public static Method methodWithDifferentAnnotation = MethodTests.method("methodWithDifferentAnnotation");
+    public static Method methodWithNoAnnotations = MethodTests.method("methodWithNoAnnotations");
+
+}


### PR DESCRIPTION
Adds `AnnotationAssertions`, a collection of AssertJ factory methods that test for the presence of an annotation and allow assertions against the found instance.

e.g. 
```java
@Test
void isAnnotatedAsTransactionalWithNoRollbackForException() {
    assertHasAnnotation(NotificationPublisher.class, Transactional.class)
            .extracting(Transactional::noRollbackFor)
            .isEqualTo(Exception.class);
}
```