### PR TITLE
Fix assertHasAnnotation(Field) missing TYPE_USE annotations

### DIFF
--- a/src/main/java/io/blt/test/assertj/AnnotationAssertions.java
+++ b/src/main/java/io/blt/test/assertj/AnnotationAssertions.java
@@ -28,6 +28,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.stream.Stream;
 import org.assertj.core.api.ObjectAssert;
 import org.assertj.core.internal.Failures;
 
@@ -128,7 +129,12 @@ public final class AnnotationAssertions {
      * @return an assertion object for the found annotation i.e. {@code ObjectAssert<T extends Annotation>}
      */
     public static <T extends Annotation> ObjectAssert<T> assertHasAnnotation(Field field, Class<T> annotation) {
-        return assertThat(findAnnotationOfTypeOrFail(field.getAnnotations(), annotation));
+        var annotations = Stream.concat(
+                        Arrays.stream(field.getAnnotations()),
+                        Arrays.stream(field.getAnnotatedType().getAnnotations()))
+                .distinct()
+                .toArray(Annotation[]::new);
+        return assertThat(findAnnotationOfTypeOrFail(annotations, annotation));
     }
 
     private static <T extends Annotation> T findAnnotationOfTypeOrFail(Annotation[] annotations, Class<T> type) {

--- a/src/test/java/io/blt/test/assertj/AnnotationAssertionsTest.java
+++ b/src/test/java/io/blt/test/assertj/AnnotationAssertionsTest.java
@@ -35,6 +35,8 @@ import org.opentest4j.AssertionFailedError;
 
 import static io.blt.test.AssertUtils.assertValidUtilityClass;
 import static io.blt.test.assertj.AnnotationAssertions.assertHasAnnotation;
+import static io.blt.test.assertj.testable.AnnotatedElements.ClassWithTypeUseAnnotatedField;
+import static io.blt.test.assertj.testable.AnnotatedElements.TargetTypeUseAnnotation;
 import static io.blt.test.assertj.testable.AnnotatedElements.TargetFieldAnnotation;
 import static io.blt.test.assertj.testable.AnnotatedElements.TargetMethodAnnotation;
 import static io.blt.test.assertj.testable.AnnotatedElements.TargetTypeAnnotation;
@@ -184,6 +186,14 @@ class AnnotationAssertionsTest {
                 .isThrownBy(() -> objectAssert
                         .extracting(TargetFieldAnnotation::name)
                         .isEqualTo(expected));
+    }
+
+    @Test
+    void assertHasAnnotationShouldFindTypeUseAnnotationOnField() throws NoSuchFieldException {
+        var field = ClassWithTypeUseAnnotatedField.class.getField("typeUseAnnotatedField");
+
+        assertThatNoException()
+                .isThrownBy(() -> assertHasAnnotation(field, TargetTypeUseAnnotation.class));
     }
 
 }

--- a/src/test/java/io/blt/test/assertj/testable/AnnotatedElements.java
+++ b/src/test/java/io/blt/test/assertj/testable/AnnotatedElements.java
@@ -30,7 +30,6 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-
 /**
  * Holds testable elements for annotation testing
  */
@@ -76,6 +75,17 @@ public final class AnnotatedElements {
     @Target(ElementType.FIELD)
     @Retention(RetentionPolicy.RUNTIME)
     public @interface DifferentFieldAnnotation {}
+
+    @Target(ElementType.TYPE_USE)
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface TargetTypeUseAnnotation {
+        String name() default "type use annotation default name";
+    }
+
+    public static class ClassWithTypeUseAnnotatedField {
+        @TargetTypeUseAnnotation
+        public String typeUseAnnotatedField;
+    }
 
     public static class MethodTests {
 


### PR DESCRIPTION
`field.getAnnotations()` only reads `RuntimeVisibleAnnotations` (declaration annotations). Annotations with `@Target(TYPE_USE)` — such as JSpecify's `@Nullable` — are stored in `RuntimeVisibleTypeAnnotations` and are therefore invisible to `assertHasAnnotation(Field, Class)`.

- Fix by searching both `field.getAnnotations()` and `field.getAnnotatedType().getAnnotations()`, with `distinct()` so annotations that appear in both slots (those targeting both `FIELD` and `TYPE_USE`) are not returned twice
- Add a record-based test fixture with a `TYPE_USE`-only annotation to reproduce the issue